### PR TITLE
Update badges.json with latest release URLs

### DIFF
--- a/badges.json
+++ b/badges.json
@@ -250,7 +250,7 @@
             "name": "LightningPop",
             "url": "https://github.com/GarlicRot/LightningPop",
             "releaseUrl": "https://github.com/GarlicRot/LightningPop/releases",
-            "latestReleaseUrl": "https://github.com/GarlicRot/LightningPop/releases/download/v1.0.2/LightningPop-1.0.2.jar",
+            "latestReleaseUrl": "https://github.com/GarlicRot/LightningPop/releases/download/v1.0.3/LightningPop-1.0.3.jar",
             "releaseDate": "August 09, 2024",
             "color": "green",
             "description": "A RusherHacks Plugin - Spawns Lightning On Totem Pops And Player Deaths - LightningPop."


### PR DESCRIPTION
This pull request includes a small change to the `badges.json` file. The change updates the `latestReleaseUrl` for the LightningPop project to reflect the new version 1.0.3.

* [`badges.json`](diffhunk://#diff-8c2848a26142b970163495896463e3113eee179041df0d89bd745a6bc3b9e8deL253-R253): Updated the `latestReleaseUrl` from version 1.0.2 to version 1.0.3.